### PR TITLE
Updating ElasticSearch URL

### DIFF
--- a/docs/1.1.9/tutorials/getting-started-centralized.md
+++ b/docs/1.1.9/tutorials/getting-started-centralized.md
@@ -42,7 +42,7 @@ for easy downloading of ElasticSearch:
 
     ES_PACKAGE=elasticsearch-0.20.2.zip
     ES_DIR=${ES_PACKAGE%%.zip}
-    SITE=https://github.com/downloads/elasticsearch/elasticsearch
+    SITE=https://download.elasticsearch.org/elasticsearch/elasticsearch
     if [ ! -d "$ES_DIR" ] ; then
       wget --no-check-certificate $SITE/$ES_PACKAGE
       unzip $ES_PACKAGE


### PR DESCRIPTION
The URL present in the shell script for downloading ElasticSearch no longer works. 
This updates to the current download location.
