### PR TITLE
Update link in getting-started-simple.md

### DIFF
--- a/docs/1.1.10/tutorials/getting-started-simple.md
+++ b/docs/1.1.10/tutorials/getting-started-simple.md
@@ -25,7 +25,7 @@ If you have problems, feel free to email the users list
 
 ## logstash
 
-You should download the logstash 'monolithic' jar - if you haven't yet, [download it now](http://logstash.objects.dreamhost.com/release/logstash-1.1.10-flatjar.jar). This package includes most
+You should download the logstash 'monolithic' jar - if you haven't yet, [download it now](http://logstash.objects.dreamhost.com/release/logstash-1.1.10-monolithic.jar). This package includes most
 of the dependencies for logstash in it and helps you get started quicker.
 
 The configuration of any logstash agent consists of specifying inputs, filters,


### PR DESCRIPTION
One of the paragraphs on this page instructs users to download the monolithic JAR file, but the link is to the flat jar.  This fix changes the target of the link to point to the monolithic JAR.
