### PR TITLE
LOGSTASH-1553: Docs: Changed all dead links to the flatjar to a working url

### DIFF
--- a/docs/1.2.2/learn.md
+++ b/docs/1.2.2/learn.md
@@ -38,7 +38,7 @@ for such things, that works for me, too.)
 
 ## Download It
 
-[Download logstash-1.2.2](https://logstash.objects.dreamhost.com/release/logstash-1.2.2-flatjar.jar)
+[Download logstash-1.2.2](https://download.elasticsearch.org/logstash/logstash/logstash-1.2.2-flatjar.jar)
 
 ## What's next?
 

--- a/docs/1.2.2/tutorials/10-minute-walkthrough/index.md
+++ b/docs/1.2.2/tutorials/10-minute-walkthrough/index.md
@@ -8,7 +8,7 @@ layout: content_right
 
 ### Download logstash:
 
-* [logstash-1.2.2-flatjar.jar](http://logstash.objects.dreamhost.com/release/logstash-1.2.2-flatjar.jar)
+* [logstash-1.2.2-flatjar.jar](https://download.elasticsearch.org/logstash/logstash/logstash-1.2.2-flatjar.jar)
 
 ### Requirements:
 

--- a/docs/1.2.2/tutorials/getting-started-centralized.md
+++ b/docs/1.2.2/tutorials/getting-started-centralized.md
@@ -75,7 +75,7 @@ ready to configure logstash.
 Download the logstash release jar file. The package contains all
 required dependencies to save you time chasing down requirements.
 
-Follow [this link to download logstash-1.2.2](http://logstash.objects.dreamhost.com/release/logstash-1.2.2-flatjar.jar).
+Follow [this link to download logstash-1.2.2](https://download.elasticsearch.org/logstash/logstash/logstash-1.2.2-flatjar.jar).
 
 Since we're doing a centralized configuration, you'll have two main
 logstash agent roles: a shipper and an indexer. You will ship logs from

--- a/docs/1.2.2/tutorials/getting-started-simple.md
+++ b/docs/1.2.2/tutorials/getting-started-simple.md
@@ -27,7 +27,7 @@ If you have problems, feel free to email the users list
 
 You should download the logstash jar file - if you haven't yet,
 [download it
-now](http://logstash.objects.dreamhost.com/release/logstash-1.2.2-flatjar.jar).
+now](https://download.elasticsearch.org/logstash/logstash/logstash-1.2.2-flatjar.jar).
 This package includes most of the dependencies for logstash in it and
 helps you get started quicker.
 


### PR DESCRIPTION
See issue https://logstash.jira.com/browse/LOGSTASH-1553
## I changed all the dead links to the URL used on http://logstash.net.

Yesterday I created pull request https://github.com/logstash/logstash/pull/755 as well. I'm not sure where this belongs.
